### PR TITLE
Hide graphic/map toggle on explore.html for safari.

### DIFF
--- a/sass/_temp-hacks.scss
+++ b/sass/_temp-hacks.scss
@@ -1,0 +1,3 @@
+html.temp-browser-is-safari .temp-hide-for-safari {
+  display: none;
+}

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -38,6 +38,7 @@
 @import 'claudio-custom-components';
 @import 'claudio-custom';
 
+@import 'temp-hacks';
 
 @import 'custom/scrollspy';
 

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -18,7 +18,7 @@
         </div>
     </div>
 </div> -->
-<div class="tab-controller show-for-large">
+<div class="tab-controller show-for-large temp-hide-for-safari">
 <div class="b-button e-explore-tab active-tab" id="explore-button-graphic">Graphic</div>
 <div class="b-button e-explore-tab" id="explore-button-map">Map</div>
 </div>

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -466,3 +466,20 @@ window.Feed({
     }
 
 })();
+
+$(function() {
+    // http://stackoverflow.com/a/7768006
+
+    var is_chrome = navigator.userAgent.indexOf('Chrome') > -1;
+    var is_explorer = navigator.userAgent.indexOf('MSIE') > -1;
+    var is_firefox = navigator.userAgent.indexOf('Firefox') > -1;
+    var is_safari = navigator.userAgent.indexOf("Safari") > -1;
+    var is_opera = navigator.userAgent.toLowerCase().indexOf("op") > -1;
+
+    if ((is_chrome)&&(is_safari)) {is_safari=false;}
+    if ((is_chrome)&&(is_opera)) {is_chrome=false;}
+
+    if (is_safari) {
+        $('html').addClass('temp-browser-is-safari');
+    }
+});


### PR DESCRIPTION
This hides the following buttons on Safari, I guess because the map isn't currently working on Safari:

![graphic-map-btns](https://cloud.githubusercontent.com/assets/124687/13994350/bc3c66f0-f0fa-11e5-9fd4-345f08406f49.png)

